### PR TITLE
Compare lists within `assert_data_equal`

### DIFF
--- a/docs/api-reference/expr_str.md
+++ b/docs/api-reference/expr_str.md
@@ -11,6 +11,7 @@
         - replace
         - replace_all
         - slice
+        - split
         - starts_with
         - strip_chars
         - tail

--- a/docs/api-reference/series_str.md
+++ b/docs/api-reference/series_str.md
@@ -11,6 +11,7 @@
         - replace
         - replace_all
         - slice
+        - split
         - starts_with
         - strip_chars
         - tail

--- a/narwhals/_arrow/expr_str.py
+++ b/narwhals/_arrow/expr_str.py
@@ -67,6 +67,11 @@ class ArrowExprStringNamespace:
             self._compliant_expr, "str", "slice", offset=offset, length=length
         )
 
+    def split(self: Self, by: str, *, inclusive: bool) -> ArrowExpr:
+        return reuse_series_namespace_implementation(
+            self._compliant_expr, "str", "split", by=by, inclusive=inclusive
+        )
+
     def to_datetime(self: Self, format: str | None) -> ArrowExpr:  # noqa: A002
         return reuse_series_namespace_implementation(
             self._compliant_expr, "str", "to_datetime", format=format

--- a/narwhals/_arrow/series_str.py
+++ b/narwhals/_arrow/series_str.py
@@ -72,9 +72,7 @@ class ArrowSeriesStringNamespace:
         )
 
     def split(self: Self, by: str, *, inclusive: bool) -> ArrowSeries:
-        split_series = pc.split_pattern(
-            self._compliant_series._native_series.combine_chunks(), by
-        )
+        split_series = pc.split_pattern(self._compliant_series._native_series, by)  # type: ignore[call-overload]
         return self._compliant_series._from_native_series(split_series)
 
     def to_datetime(self: Self, format: str | None) -> ArrowSeries:  # noqa: A002

--- a/narwhals/_arrow/series_str.py
+++ b/narwhals/_arrow/series_str.py
@@ -71,6 +71,12 @@ class ArrowSeriesStringNamespace:
             )
         )
 
+    def split(self: Self, by: str, *, inclusive: bool) -> ArrowSeries:
+        split_series = pc.split_pattern(
+            self._compliant_series._native_series.combine_chunks(), by
+        )
+        return self._compliant_series._from_native_series(split_series)
+
     def to_datetime(self: Self, format: str | None) -> ArrowSeries:  # noqa: A002
         native = self._compliant_series._native_series
         format = parse_datetime_format(native) if format is None else format

--- a/narwhals/_dask/expr_str.py
+++ b/narwhals/_dask/expr_str.py
@@ -94,6 +94,25 @@ class DaskExprStringNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
         )
 
+    def split(self: Self, by: str | None, *, inclusive: bool) -> DaskExpr:
+        if inclusive:
+            return self._compliant_expr._from_call(
+                lambda _input, by: _input.str.split(pat=by).apply(
+                    lambda x: [
+                        f"{x[i]}{by}" if i < len(x) - 1 else x[i] for i in range(len(x))
+                    ]
+                ),
+                "split",
+                by=by,
+                returns_scalar=self._compliant_expr._returns_scalar,
+            )
+        return self._compliant_expr._from_call(
+            lambda _input, by: _input.str.split(pat=by),
+            "split",
+            by=by,
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
     def to_datetime(self: Self, format: str | None) -> DaskExpr:  # noqa: A002
         return self._compliant_expr._from_call(
             lambda _input, format: dd.to_datetime(_input, format=format),  # noqa: A006

--- a/narwhals/_duckdb/expr_str.py
+++ b/narwhals/_duckdb/expr_str.py
@@ -60,6 +60,26 @@ class DuckDBExprStringNamespace:
             func, "slice", expr_kind=self._compliant_expr._expr_kind
         )
 
+    def split(self: Self, by: str | None, *, inclusive: bool) -> DuckDBExpr:
+        def func(_input: duckdb.Expression) -> duckdb.Expression:
+            split_expr = FunctionExpression("str_split", _input, lit(by))
+            if inclusive:
+                array_to_string_expr = FunctionExpression(
+                    "array_to_string", split_expr, lit("|")
+                )
+                regexp_replace_expr = FunctionExpression(
+                    "regexp_replace",
+                    array_to_string_expr,
+                    lit(r"\|"),
+                    lit(f"{by}|"),
+                )
+                return FunctionExpression("str_split", regexp_replace_expr, lit("|"))
+            return split_expr
+
+        return self._compliant_expr._from_call(
+            func, "split", expr_kind=self._compliant_expr._expr_kind
+        )
+
     def len_chars(self: Self) -> DuckDBExpr:
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("length", _input),

--- a/narwhals/_pandas_like/expr_str.py
+++ b/narwhals/_pandas_like/expr_str.py
@@ -93,6 +93,11 @@ class PandasLikeExprStringNamespace:
             self._compliant_expr, "str", "slice", offset=offset, length=length
         )
 
+    def split(self: Self, by: str | None, *, inclusive: bool) -> PandasLikeExpr:
+        return reuse_series_namespace_implementation(
+            self._compliant_expr, "str", "split", by=by, inclusive=inclusive
+        )
+
     def to_datetime(self: Self, format: str | None) -> PandasLikeExpr:  # noqa: A002
         return reuse_series_namespace_implementation(
             self._compliant_expr,

--- a/narwhals/_pandas_like/series_str.py
+++ b/narwhals/_pandas_like/series_str.py
@@ -61,6 +61,18 @@ class PandasLikeSeriesStringNamespace:
             self._compliant_series._native_series.str.slice(start=offset, stop=stop),
         )
 
+    def split(self: Self, by: str | None, *, inclusive: bool) -> PandasLikeSeries:
+        split_series = self._compliant_series._native_series.str.split(pat=by)
+        if inclusive:
+            return self._compliant_series._from_native_series(
+                split_series.apply(
+                    lambda x: [
+                        f"{x[i]}{by}" if i < len(x) - 1 else x[i] for i in range(len(x))
+                    ]
+                )
+            )
+        return self._compliant_series._from_native_series(split_series)
+
     def to_datetime(self: Self, format: str | None) -> PandasLikeSeries:  # noqa: A002
         return self._compliant_series._from_native_series(
             to_datetime(self._compliant_series._implementation)(

--- a/narwhals/_spark_like/expr_str.py
+++ b/narwhals/_spark_like/expr_str.py
@@ -112,6 +112,28 @@ class SparkLikeExprStringNamespace:
             expr_kind=self._compliant_expr._expr_kind,
         )
 
+    def split(self: Self, by: str | None, *, inclusive: bool) -> SparkLikeExpr:
+        def func(_input: Column) -> Column:
+            split_expr = self._compliant_expr._F.split(_input, by)
+            if inclusive:
+                length = self._compliant_expr._F.size(split_expr)
+                return self._compliant_expr._F.transform(
+                    split_expr,
+                    lambda x, i: self._compliant_expr._F.when(
+                        i < length - 1,
+                        self._compliant_expr._F.concat(
+                            x, self._compliant_expr._F.lit(by)
+                        ),
+                    ).otherwise(x),
+                )
+            return split_expr
+
+        return self._compliant_expr._from_call(
+            func,
+            "split",
+            expr_kind=self._compliant_expr._expr_kind,
+        )
+
     def to_uppercase(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             self._compliant_expr._F.upper,

--- a/narwhals/expr_str.py
+++ b/narwhals/expr_str.py
@@ -574,6 +574,14 @@ class ExprStringNamespace(Generic[ExprT]):
             self._expr._metadata,
         )
 
+    def split(self: Self, by: str | None = None, *, inclusive: bool) -> ExprT:
+        return self._expr.__class__(
+            lambda plx: self._expr._to_compliant_expr(plx).str.split(
+                by=by, inclusive=inclusive
+            ),
+            self._expr._metadata,
+        )
+
     def head(self: Self, n: int = 5) -> ExprT:
         r"""Take the first n elements of each string.
 

--- a/narwhals/series_str.py
+++ b/narwhals/series_str.py
@@ -547,6 +547,11 @@ class SeriesStringNamespace(Generic[SeriesT]):
             )
         )
 
+    def split(self: Self, by: str | None = None, *, inclusive: bool = False) -> SeriesT:
+        return self._narwhals_series._from_compliant_series(
+            self._narwhals_series._compliant_series.str.split(by=by, inclusive=inclusive)
+        )
+
     def head(self: Self, n: int = 5) -> SeriesT:
         r"""Take the first n elements of each string.
 

--- a/tests/expr_and_series/str/split_test.py
+++ b/tests/expr_and_series/str/split_test.py
@@ -62,4 +62,4 @@ def test_str_split_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["s"].str.split(by=by, inclusive=inclusive)
-    assert_equal_data(({"s": result_series}), expected.all())
+    assert_equal_data({"s": result_series}, expected)

--- a/tests/expr_and_series/str/split_test.py
+++ b/tests/expr_and_series/str/split_test.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import narwhals.stable.v1 as nw
+from tests.utils import Constructor
+from tests.utils import ConstructorEager
+from tests.utils import assert_equal_data
+
+data = {"s": ["foo bar", "foo_bar", "foo_bar_baz", "foo,bar"]}
+
+
+@pytest.mark.parametrize(
+    ("by", "inclusive", "expected"),
+    [
+        ("_", False, {"s": ["foo bar", "foobar", "foobarbaz", "foo,bar"]}),
+        (
+            "_",
+            True,
+            {"s": ["foo bar", "foo_bar", "foo_bar_baz", "foo,bar"]},
+        ),
+    ],
+)
+def test_str_split(
+    constructor: Constructor,
+    by: str | None,
+    inclusive: bool,  # noqa: FBT001
+    expected: Any,
+) -> None:
+    df = nw.from_native(constructor(data))
+    result_frame = df.select(nw.col("s").str.split(by=by, inclusive=inclusive))
+    assert_equal_data(result_frame, expected)
+
+
+@pytest.mark.parametrize(
+    ("by", "inclusive", "expected"),
+    [
+        ("_", False, {"s": ["foo bar", "foobar", "foobarbaz", "foo,bar"]}),
+        (
+            "_",
+            True,
+            {"s": ["foo bar", "foo_bar", "foo_bar_baz", "foo,bar"]},
+        ),
+    ],
+)
+def test_str_split_series(
+    constructor_eager: ConstructorEager,
+    by: str | None,
+    inclusive: bool,  # noqa: FBT001
+    expected: Any,
+) -> None:
+    df = nw.from_native(constructor_eager(data), eager_only=True)
+
+    result_series = df["s"].str.split(by=by, inclusive=inclusive)
+    assert_equal_data({"s": result_series}, expected)

--- a/tests/expr_and_series/str/split_test.py
+++ b/tests/expr_and_series/str/split_test.py
@@ -15,11 +15,11 @@ data = {"s": ["foo bar", "foo_bar", "foo_bar_baz", "foo,bar"]}
 @pytest.mark.parametrize(
     ("by", "inclusive", "expected"),
     [
-        ("_", False, {"s": ["foo bar", "foobar", "foobarbaz", "foo,bar"]}),
+        ("_", False, {"s": [["foo bar"], ["foobar"], ["foobarbaz"], ["foo,bar"]]}),
         (
             "_",
             True,
-            {"s": ["foo bar", "foo_bar", "foo_bar_baz", "foo,bar"]},
+            {"s": [["foo bar"], ["foo_bar"], ["foo_bar_baz"], ["foo,bar"]]},
         ),
     ],
 )
@@ -37,11 +37,11 @@ def test_str_split(
 @pytest.mark.parametrize(
     ("by", "inclusive", "expected"),
     [
-        ("_", False, {"s": ["foo bar", "foobar", "foobarbaz", "foo,bar"]}),
+        ("_", False, {"s": [["foo bar"], ["foobar"], ["foobarbaz"], ["foo,bar"]]}),
         (
             "_",
             True,
-            {"s": ["foo bar", "foo_bar", "foo_bar_baz", "foo,bar"]},
+            {"s": [["foo bar"], ["foo_bar"], ["foo_bar_baz"], ["foo,bar"]]},
         ),
     ],
 )

--- a/tests/expr_and_series/str/split_test.py
+++ b/tests/expr_and_series/str/split_test.py
@@ -62,4 +62,4 @@ def test_str_split_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["s"].str.split(by=by, inclusive=inclusive)
-    assert_equal_data({"s": result_series}, expected)
+    assert_equal_data(({"s": result_series}), expected.all())

--- a/tests/expr_and_series/str/split_test.py
+++ b/tests/expr_and_series/str/split_test.py
@@ -25,7 +25,7 @@ data = {"s": ["foo bar", "foo_bar", "foo_bar_baz", "foo,bar"]}
 )
 def test_str_split(
     constructor: Constructor,
-    by: str | None,
+    by: str,
     inclusive: bool,  # noqa: FBT001
     expected: Any,
 ) -> None:

--- a/tests/expr_and_series/str/split_test.py
+++ b/tests/expr_and_series/str/split_test.py
@@ -15,11 +15,15 @@ data = {"s": ["foo bar", "foo_bar", "foo_bar_baz", "foo,bar"]}
 @pytest.mark.parametrize(
     ("by", "inclusive", "expected"),
     [
-        ("_", False, {"s": [["foo bar"], ["foobar"], ["foobarbaz"], ["foo,bar"]]}),
+        (
+            "_",
+            False,
+            {"s": [["foo bar"], ["foo", "bar"], ["foo", "bar", "baz"], ["foo,bar"]]},
+        ),
         (
             "_",
             True,
-            {"s": [["foo bar"], ["foo_bar"], ["foo_bar_baz"], ["foo,bar"]]},
+            {"s": [["foo bar"], ["foo_", "bar"], ["foo_bar_baz"], ["foo,bar"]]},
         ),
     ],
 )
@@ -37,11 +41,15 @@ def test_str_split(
 @pytest.mark.parametrize(
     ("by", "inclusive", "expected"),
     [
-        ("_", False, {"s": [["foo bar"], ["foobar"], ["foobarbaz"], ["foo,bar"]]}),
+        (
+            "_",
+            False,
+            {"s": [["foo bar"], ["foo", "bar"], ["foo", "bar", "baz"], ["foo,bar"]]},
+        ),
         (
             "_",
             True,
-            {"s": [["foo bar"], ["foo_bar"], ["foo_bar_baz"], ["foo,bar"]]},
+            {"s": [["foo bar"], ["foo_", "bar"], ["foo_bar_baz"], ["foo,bar"]]},
         ),
     ],
 )

--- a/tests/expr_and_series/str/split_test.py
+++ b/tests/expr_and_series/str/split_test.py
@@ -23,7 +23,7 @@ data = {"s": ["foo bar", "foo_bar", "foo_bar_baz", "foo,bar"]}
         (
             "_",
             True,
-            {"s": [["foo bar"], ["foo_", "bar"], ["foo_bar_baz"], ["foo,bar"]]},
+            {"s": [["foo bar"], ["foo_", "bar"], ["foo_", "bar_", "baz"], ["foo,bar"]]},
         ),
     ],
 )
@@ -49,7 +49,7 @@ def test_str_split(
         (
             "_",
             True,
-            {"s": [["foo bar"], ["foo_", "bar"], ["foo_bar_baz"], ["foo,bar"]]},
+            {"s": [["foo bar"], ["foo_", "bar"], ["foo_", "bar_", "baz"], ["foo,bar"]]},
         ),
     ],
 )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -131,6 +131,8 @@ def assert_equal_data(result: Any, expected: Mapping[str, Any]) -> None:
                 are_equivalent_values = lhs is None or math.isnan(lhs)
             elif lhs is None:
                 are_equivalent_values = rhs is None
+            elif isinstance(lhs, list) and isinstance(rhs, list):
+                are_equivalent_values = all(l == r for l, r in zip(lhs, rhs))
             elif pd.isna(lhs):
                 are_equivalent_values = pd.isna(rhs)
             else:


### PR DESCRIPTION
It seems that `str.split` is going to be one of the first methods that returns a Series with a list datatype! So the utility function `assert_data_equal` didn't know how to handle nested lists. Thankfully a crude implementation was just 2 lines of code.

I ran the tests locally and it seems like there is no PyArrow implementation for `inclusive=True`. This is fine considering the limited choice of pyarrow compute functions available, I would add the following 2 pieces of code:

- `narwhals/_arrow/series_str.py` check `if inclusive:` and raise `NotImplementedError`
- `tests/expr_and_series/str/split_test.py` add an `xfail` if `inclusive is True` and if the constructor is the pyarrow_table_constructor
    - This will notify pytest that we are expecting to fail this particular test due to raising the NotImplementedError

For the latter point, you can refer to: https://github.com/skritsotalakis/narwhals/blob/8442d3936cf5f35215192e3628cc5b0a9df59dde/tests/expr_and_series/diff_test.py#L21-L23